### PR TITLE
work menu: remove target attribute left over from iframe

### DIFF
--- a/work/work_header.html
+++ b/work/work_header.html
@@ -32,7 +32,7 @@
                               <div class="decadeTitle" style="margin-right:10px;">Select Decade</div>
                               <br/>
                               <div style="line-height: 4em;">
-				                    <div class="decadeItem" style="padding-left:10px;"><a href="/work/2010.php" target="decade">2010's</a></div>
+				    <div class="decadeItem" style="padding-left:10px;"><a href="/work/2010.php">2010's</a></div>
                                     <div class="decadeItem" style="padding-left:10px;"><a href="/work/2000.php">2000's</a></div>
                                     <div class="decadeItem" style="padding-left:10px;"><a href="/work/1990.php">1990's</a></div>
                                     <div class="decadeItem" style="padding-left:10px;"><a href="/work/1980.php">1980's</a></div>


### PR DESCRIPTION
I missed one of the links accidentally in my previous patch
