### PR TITLE
Search enhancements

### DIFF
--- a/src/search/index.js
+++ b/src/search/index.js
@@ -108,7 +108,6 @@ SearchView.prototype.match = function (item, query) {
   var matches = []
   for (var field in item) {
     if (field === 'id' || field === 'type' || field === 'attachmentUrl') continue
-    if (item.type === 'works' && field === 'title') continue
     field = item[field]
     if (Array.isArray(field)) {
       if (typeof field[0] === 'object') {

--- a/src/search/index.js
+++ b/src/search/index.js
@@ -146,7 +146,7 @@ function tokenizeQuery (query) {
       term !== 'then' &&
       term !== 'there'
   }).map(function (term) {
-    return new RegExp('\\b' + escapeRegExp(term) + '\\b', 'ig')
+    return new RegExp('\\b' + escapeRegExp(term), 'ig')
   })
 }
 


### PR DESCRIPTION
I was looking for something on your site the other day and noticed search wasn't turning it up even though I knew I had the right query - from looking at the code I can see for some reason we decided:
* not to match on work titles
* to only match entire words instead of more liberally matching parts of words (from the beginning of the word at least)

I propose we eliminate both of these restrictions... what do you think? So you can see what it's like, I've pushed this branch to production for now but can easily roll it back if it's not to your liking, let me know.